### PR TITLE
fix the missing error handling

### DIFF
--- a/router/posts.go
+++ b/router/posts.go
@@ -296,6 +296,11 @@ func PostsHandler(w http.ResponseWriter, r *http.Request) {
 
 		dsn := os.Getenv("dbdsn")
 		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			log.Printf("ERROR: db open err: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		defer db.Close()
 
 		row := db.QueryRow("select user_id from session where token = ? limit 1", token.Value)
@@ -378,6 +383,11 @@ func PostsHandler(w http.ResponseWriter, r *http.Request) {
 		  order by
 		    p.created_at desc
 		`)
+		if err != nil {
+			log.Printf("ERROR: exec posts query err: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		defer db.Close()
 
 		var posts []model.Post

--- a/router/user.go
+++ b/router/user.go
@@ -91,7 +91,11 @@ func UsersHandler(w http.ResponseWriter, r *http.Request) {
 		var user_id int
 		var current_user_salt string
 		var current_user_hashed_password string
-		exsist_user_row.Scan(&user_id, &current_user_hashed_password, &current_user_salt)
+		if err := exsist_user_row.Scan(&user_id, &current_user_hashed_password, &current_user_salt); err != nil && err != sql.ErrNoRows {
+			log.Printf("ERROR: db scan user err: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 
 		password := r.FormValue("password")
 		if !(utf8.RuneCountInString(password) >= 1 && utf8.RuneCountInString(password) <= 100) {
@@ -210,6 +214,11 @@ func UsersHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		rows, err := db.Query("select * from users")
+		if err != nil {
+			log.Printf("ERROR: exec users query err: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 
 		var users []model.User
 		for rows.Next() {


### PR DESCRIPTION
お節介だったらすみません。

error handling の不足があったのでこんな感じで追加するのはどうでしょう？

ちなみに [golangci-lint](https://golangci-lint.run/) の staticcheck という linter が error handling の漏れをある程度教えてくれます。
僕は手元の VSCode の setting.json で `"go.lintTool": "golangci-lint",` を設定して、気がつけるようにしています。

```bash
$ golangci-lint run ./...
router/user.go:94:23: Error return value of `exsist_user_row.Scan` is not checked (errcheck)
                exsist_user_row.Scan(&user_id, &current_user_hashed_password, &current_user_salt)
                                    ^
router/posts.go:298:7: ineffectual assignment to err (ineffassign)
                db, err := sql.Open("mysql", dsn)
                    ^
router/posts.go:368:9: ineffectual assignment to err (ineffassign)
                rows, err := db.Query(`
                      ^
router/user.go:212:9: ineffectual assignment to err (ineffassign)
                rows, err := db.Query("select * from users")
                      ^
router/home.go:28:2: SA5001: should check returned error before deferring db.Close() (staticcheck)
        defer db.Close()
        ^
router/posts.go:86:3: SA5001: should check returned error before deferring db.Close() (staticcheck)
                defer db.Close()
                ^
router/posts.go:235:3: SA5001: should check returned error before deferring db.Close() (staticcheck)
                defer db.Close()
                ^
```